### PR TITLE
Get member count endpoint

### DIFF
--- a/lib/phoenix-client.js
+++ b/lib/phoenix-client.js
@@ -34,10 +34,6 @@ class PhoenixClient {
     this.User = new PhoenixEndpointUser(this);
   }
 
-  getMemberCount() {
-    return this.User.getCount();
-  }
-
 }
 
 module.exports = PhoenixClient;

--- a/lib/phoenix-client.js
+++ b/lib/phoenix-client.js
@@ -1,13 +1,16 @@
 'use strict';
 
-const request = require('superagent');
+/**
+ * Includes.
+ */
+const PhoenixEndpointUser = require('./phoenix-endpoint-user');
+const VERSION = require('../package.json').version;
 
 /**
  * PhoenixClient
  */
 
 // Package version
-const VERSION = require('../package.json').version;
 
 class PhoenixClient {
 
@@ -26,37 +29,13 @@ class PhoenixClient {
 
     // Defaults.
     this.VERSION = VERSION;
+
+    // UserEndpoint
+    this.User = new PhoenixEndpointUser(this);
   }
 
-  /**
-   * Get member count.
-   */
   getMemberCount() {
-    // TODO: user namespace to subclass.
-    // TODO: return MemberData object with formating features.
-    return this
-      .executePost('users/get_member_count')
-      .then(response => this.parseResponse(response));
-  }
-
-  /**
-   * Helper function to execute simple get.
-   */
-  executePost(endpoint) {
-    const agent = request
-      .post(`${this.baseURI}/${endpoint}`)
-      .accept('json');
-    return agent;
-  }
-
-  /**
-   * Helper function to parse response body to a NorthstarUser.
-   */
-  parseResponse(response) {
-    if (!response.body) {
-      throw new Error('Cannot parse API response.');
-    }
-    return response.body;
+    return this.User.getCount();
   }
 
 }

--- a/lib/phoenix-client.js
+++ b/lib/phoenix-client.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Includes.
+ * Imports.
  */
 const PhoenixEndpointUser = require('./phoenix-endpoint-user');
 const VERSION = require('../package.json').version;

--- a/lib/phoenix-client.js
+++ b/lib/phoenix-client.js
@@ -1,9 +1,9 @@
 'use strict';
 
-// const request = require('superagent');
+const request = require('superagent');
 
 /**
- * NorthstarClient
+ * PhoenixClient
  */
 
 // Package version
@@ -26,6 +26,37 @@ class PhoenixClient {
 
     // Defaults.
     this.VERSION = VERSION;
+  }
+
+  /**
+   * Get member count.
+   */
+  getMemberCount() {
+    // TODO: user namespace to subclass.
+    // TODO: return MemberData object with formating features.
+    return this
+      .executePost('users/get_member_count')
+      .then(response => this.parseResponse(response));
+  }
+
+  /**
+   * Helper function to execute simple get.
+   */
+  executePost(endpoint) {
+    const agent = request
+      .post(`${this.baseURI}/${endpoint}`)
+      .accept('json');
+    return agent;
+  }
+
+  /**
+   * Helper function to parse response body to a NorthstarUser.
+   */
+  parseResponse(response) {
+    if (!response.body) {
+      throw new Error('Cannot parse API response.');
+    }
+    return response.body;
   }
 
 }

--- a/lib/phoenix-endpoint-user.js
+++ b/lib/phoenix-endpoint-user.js
@@ -21,8 +21,7 @@ class PhoenixEndpointUser extends PhoenixEndpoint {
    * Get member count.
    */
   getCount() {
-    // TODO: user namespace to subclass.
-    // TODO: return MemberData object with formating features.
+    // TODO: return MemberData object with formating features?
     return this
       .callAction('get_member_count')
       .then(response => this.parseResponse(response));

--- a/lib/phoenix-endpoint-user.js
+++ b/lib/phoenix-endpoint-user.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * Includes.
+ */
+const PhoenixEndpoint = require('./phoenix-endpoint');
+
+
+/**
+ * PhoenixEndpointUser.
+ */
+
+class PhoenixEndpointUser extends PhoenixEndpoint {
+
+  constructor(client) {
+    super(client);
+    this.endpoint = 'users';
+  }
+
+  /**
+   * Get member count.
+   */
+  getCount() {
+    // TODO: user namespace to subclass.
+    // TODO: return MemberData object with formating features.
+    return this
+      .callAction('get_member_count')
+      .then(response => this.parseResponse(response));
+  }
+
+}
+
+module.exports = PhoenixEndpointUser;

--- a/lib/phoenix-endpoint-user.js
+++ b/lib/phoenix-endpoint-user.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Includes.
+ * Imports.
  */
 const PhoenixEndpoint = require('./phoenix-endpoint');
 

--- a/lib/phoenix-endpoint.js
+++ b/lib/phoenix-endpoint.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const request = require('superagent');
+
+/**
+ * PhoenixEndpointUser.
+ */
+
+class PhoenixEndpoint {
+
+  constructor(client) {
+    this.client = client;
+  }
+
+  /**
+   * Helper function to execute method.
+   */
+  callAction(name) {
+    return this.executePost(`${this.endpoint}/${name}`);
+  }
+
+  /**
+   * Helper function to execute simple post.
+   */
+  executePost(endpoint) {
+    const agent = request
+      .post(`${this.client.baseURI}/${endpoint}`)
+      .accept('json');
+    return agent;
+  }
+
+  /**
+   * Helper function to parse response body to a NorthstarUser.
+   */
+  parseResponse(response) {
+    if (!response.body) {
+      throw new Error('Cannot parse API response.');
+    }
+    return response.body;
+  }
+
+}
+
+module.exports = PhoenixEndpoint;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dosomething/phoenix-js",
   "version": "0.0.0",
-  "description": "Javascript client for Northstar, the DoSomething.org user API.",
+  "description": "Javascript client for Phoenix, the DoSomething.org user API.",
   "engines": {
     "node": ">=4.4.x"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosomething/phoenix-js",
-  "version": "0.0.0",
+  "version": "0.0.1-0",
   "description": "Javascript client for Phoenix, the DoSomething.org user API.",
   "engines": {
     "node": ">=4.4.x"

--- a/test/phoenix-client.test.js
+++ b/test/phoenix-client.test.js
@@ -4,11 +4,40 @@
  * NorthstarClient.test
  */
 require('dotenv').config({ silent: true });
-// const PhoenixClient = require('../lib/phoenix-client');
+const PhoenixClient = require('../lib/phoenix-client');
 
 /**
  * Test Northstar Nodejs client.
  */
 describe('PhoenixClient', () => {
+  /**
+   * Helper: get default client.
+   */
+  function getUnauthorizedClient() {
+    return new PhoenixClient({
+      baseURI: process.env.PHOENIX_REST_API_BASEURI,
+    });
+  }
 
+  // Constructor.
+  describe('constructor', () => {
+    // Test new instance.
+    it('without options should throw a TypeError', () => {
+      (() => new PhoenixClient()).should.throw(TypeError);
+    });
+
+    // Check API base URL.
+    it('base URL option should be set', () => {
+      process.env.PHOENIX_REST_API_BASEURI.should.be.not.empty();
+    });
+
+    // Test new instance.
+    it('should create new instance configured correctly', () => {
+      const client = getUnauthorizedClient();
+      client.should.be.an.instanceof(PhoenixClient);
+      client.should.have.property('baseURI').which.is.not.empty();
+      // TODO: check if authentication token isn't set.
+      // client.should.have.property('apiKey').which.is.empty();
+    });
+  });
 });

--- a/test/phoenix-client.test.js
+++ b/test/phoenix-client.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Includes.
+ * Imports.
  */
 require('dotenv').config({ silent: true });
 const PhoenixClient = require('../lib/phoenix-client');

--- a/test/phoenix-client.test.js
+++ b/test/phoenix-client.test.js
@@ -40,4 +40,31 @@ describe('PhoenixClient', () => {
       // client.should.have.property('apiKey').which.is.empty();
     });
   });
+
+
+  describe.skip('getMemberCount()', () => {
+    /**
+     * Helper: validate unauthorized user object.
+     */
+    function memberCountResponse(data) {
+      // Ensure result to be an instance of Response?
+      data.should.be.an.instanceof(Object);
+
+      // Ensure properties and test values.
+      data.should.have.properties(['formatted', 'readable']);
+    }
+
+    // Check getUser method.
+    it('getMemberCount() should be exposed', () => {
+      // property('getMemberCount').that.is.a.Function?
+      getUnauthorizedClient().getMemberCount.should.be.a.Function();
+    });
+
+    // By id.
+    it('should return correct member count', () => {
+      const client = getUnauthorizedClient();
+      const response = client.getMemberCount();
+      return response.should.eventually.match(memberCountResponse);
+    });
+  });
 });

--- a/test/phoenix-client.test.js
+++ b/test/phoenix-client.test.js
@@ -1,10 +1,15 @@
 'use strict';
 
 /**
- * PhoenixClient.test
+ * Includes.
  */
 require('dotenv').config({ silent: true });
 const PhoenixClient = require('../lib/phoenix-client');
+const PhoenixEndpointUser = require('../lib/phoenix-endpoint-user');
+
+/**
+ * PhoenixClient.test
+ */
 
 /**
  * Test Phoenix Nodejs client.
@@ -44,7 +49,7 @@ describe('PhoenixClient', () => {
   });
 
 
-  describe('getMemberCount()', () => {
+  describe('User', () => {
     /**
      * Helper: validate unauthorized user object.
      */
@@ -57,15 +62,16 @@ describe('PhoenixClient', () => {
     }
 
     // Check getUser method.
-    it('getMemberCount() should be exposed', () => {
-      // property('getMemberCount').that.is.a.Function?
-      getUnauthorizedClient().getMemberCount.should.be.a.Function();
+    it('should be exposed', () => {
+      getUnauthorizedClient()
+        .should.have.property('User')
+        .which.is.instanceof(PhoenixEndpointUser);
     });
 
     // By id.
-    it('should return correct member count', () => {
+    it('getCount() should return correct member count', () => {
       const client = getUnauthorizedClient();
-      const response = client.getMemberCount();
+      const response = client.User.getCount();
       return response.should.eventually.match(memberCountResponse);
     });
   });

--- a/test/phoenix-client.test.js
+++ b/test/phoenix-client.test.js
@@ -50,17 +50,6 @@ describe('PhoenixClient', () => {
 
 
   describe('User', () => {
-    /**
-     * Helper: validate unauthorized user object.
-     */
-    function memberCountResponse(data) {
-      // Ensure result to be an instance of Response?
-      data.should.be.an.instanceof(Object);
-
-      // Ensure properties and test values.
-      data.should.have.properties(['formatted', 'readable']);
-    }
-
     // Check getUser method.
     it('should be exposed', () => {
       getUnauthorizedClient()
@@ -68,11 +57,17 @@ describe('PhoenixClient', () => {
         .which.is.instanceof(PhoenixEndpointUser);
     });
 
-    // By id.
+    // Get member count.
     it('getCount() should return correct member count', () => {
       const client = getUnauthorizedClient();
       const response = client.User.getCount();
-      return response.should.eventually.match(memberCountResponse);
+      return response.should.eventually.match((data) => {
+        // Ensure result to be an instance of Response?
+        data.should.be.an.instanceof(Object);
+
+        // Ensure properties and test values.
+        data.should.have.properties(['formatted', 'readable']);
+      });
     });
   });
 });

--- a/test/phoenix-client.test.js
+++ b/test/phoenix-client.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
 /**
- * NorthstarClient.test
+ * PhoenixClient.test
  */
 require('dotenv').config({ silent: true });
 const PhoenixClient = require('../lib/phoenix-client');
 
 /**
- * Test Northstar Nodejs client.
+ * Test Phoenix Nodejs client.
  */
 describe('PhoenixClient', () => {
   /**
@@ -35,14 +35,16 @@ describe('PhoenixClient', () => {
     it('should create new instance configured correctly', () => {
       const client = getUnauthorizedClient();
       client.should.be.an.instanceof(PhoenixClient);
-      client.should.have.property('baseURI').which.is.not.empty();
+      client.should.have.property('baseURI')
+        .which.is.not.empty()
+        .and.equal(process.env.PHOENIX_REST_API_BASEURI);
       // TODO: check if authentication token isn't set.
       // client.should.have.property('apiKey').which.is.empty();
     });
   });
 
 
-  describe.skip('getMemberCount()', () => {
+  describe('getMemberCount()', () => {
     /**
      * Helper: validate unauthorized user object.
      */


### PR DESCRIPTION
Provides functionality to fetch member count data from Phoenix API.

Returns object:

``` json
{
    "formatted": "3,596,441",
    "readable": "3.5 million"
}
```
