### PR TITLE
Fix typo: Authrorized -> Authorized.

### DIFF
--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -22,7 +22,7 @@ module.exports = {
   /**
    * Helper: get authorized client.
    */
-  getAuthrorizedClient() {
+  getAuthorizedClient() {
     return new PhoenixClient({
       baseURI: process.env.PHOENIX_REST_API_BASEURI,
       username: process.env.PHOENIX_REST_API_USERNAME,

--- a/test/lib/constructor.test.js
+++ b/test/lib/constructor.test.js
@@ -27,7 +27,7 @@ describe('PhoenixClient constructor', () => {
 
   // Test authorized instance.
   it('should create correct authorized client', () => {
-    const client = helper.getAuthrorizedClient();
+    const client = helper.getAuthorizedClient();
     client.should.be.an.instanceof(PhoenixClient);
     client.should.have.property('session');
     return client.session.should.eventually.match(helper.validSessionData);

--- a/test/lib/system.test.js
+++ b/test/lib/system.test.js
@@ -16,7 +16,7 @@ const PhoenixEndpointSystem = require('../../lib/phoenix-endpoint-system');
 describe('PhoenixClient.System', () => {
   // Check System module.
   it('should be exposed', () => {
-    helper.getAuthrorizedClient()
+    helper.getAuthorizedClient()
       .should.have.property('System')
       .which.is.instanceof(PhoenixEndpointSystem);
   });
@@ -33,7 +33,7 @@ describe('PhoenixClient.System', () => {
 
   // Check that created client can perform authorized calls.
   it('getConnectionUserId() should return connection status', () => {
-    const client = helper.getAuthrorizedClient();
+    const client = helper.getAuthorizedClient();
     const response = client.System.getConnectionUserId();
     return response.should.eventually.match((userId) => {
       userId.should.be.a.Number().and.not.equal(0);


### PR DESCRIPTION
Fixes typo: `getAuthrorizedClient()` should be `getAuthorizedClient()`.
