### PR TITLE
Increase Mocha timeout.

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --require should
 --reporter dot
+--timeout 10000


### PR DESCRIPTION
We're testing against staging services, so default timeout of 2000ms is just not enough.
