### PR TITLE
Adds Nock, Campaigns endpoint, supports POST Signup and Reportback

### DIFF
--- a/lib/phoenix-client.js
+++ b/lib/phoenix-client.js
@@ -6,6 +6,7 @@
 const PhoenixEndpointUser = require('./phoenix-endpoint-user');
 const PhoenixEndpointAuth = require('./phoenix-endpoint-auth');
 const PhoenixEndpointSystem = require('./phoenix-endpoint-system');
+const PhoenixEndpointCampaigns = require('./phoenix-endpoint-campaigns');
 const VERSION = require('../package.json').version;
 
 /**
@@ -37,6 +38,7 @@ class PhoenixClient {
     // Endpoints.
     this.User = new PhoenixEndpointUser(this);
     this.System = new PhoenixEndpointSystem(this);
+    this.Campaigns = new PhoenixEndpointCampaigns(this);
   }
 
   authorizeSession(opts) {

--- a/lib/phoenix-endpoint-campaigns.js
+++ b/lib/phoenix-endpoint-campaigns.js
@@ -23,10 +23,7 @@ class PhoenixEndpointCampaigns extends PhoenixEndpoint {
   signup(id, data) {
     return this
       .callAction('signup', id, data)
-      .then((response) => {
-        const body = this.parseNumberResponse(response);
-        return Number(body);
-      });
+      .then(response => this.parseNumberResponse(response));
   }
 
   /**
@@ -35,10 +32,7 @@ class PhoenixEndpointCampaigns extends PhoenixEndpoint {
   reportback(id, data) {
     return this
       .callAction('reportback', id, data)
-      .then((response) => {
-        const body = this.parseNumberResponse(response);
-        return Number(body);
-      });
+      .then(response => this.parseNumberResponse(response));
   }
 }
 

--- a/lib/phoenix-endpoint-campaigns.js
+++ b/lib/phoenix-endpoint-campaigns.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const PhoenixEndpoint = require('./phoenix-endpoint');
+
+
+/**
+ * PhoenixEndpointCampaigns.
+ */
+
+class PhoenixEndpointCampaigns extends PhoenixEndpoint {
+
+  constructor(client) {
+    super(client);
+    this.endpoint = 'campaigns';
+  }
+
+  /**
+   * Post Signup for given Campaign id and data.
+   */
+  signup(id, data) {
+    return this
+      .callAction('signup', id, data)
+      .then((response) => {
+        const body = this.parseStringResponse(response);
+        return Number(body);
+      });
+  }
+
+  /**
+   * Post Reportback for given Campaign id and data.
+   */
+  reportback(id, data) {
+    return this
+      .callAction('reportback', id, data)
+      .then((response) => {
+        const body = this.parseStringResponse(response);
+        return Number(body);
+      });
+  }
+}
+
+module.exports = PhoenixEndpointCampaigns;

--- a/lib/phoenix-endpoint-campaigns.js
+++ b/lib/phoenix-endpoint-campaigns.js
@@ -24,7 +24,7 @@ class PhoenixEndpointCampaigns extends PhoenixEndpoint {
     return this
       .callAction('signup', id, data)
       .then((response) => {
-        const body = this.parseStringResponse(response);
+        const body = this.parseNumberResponse(response);
         return Number(body);
       });
   }
@@ -36,7 +36,7 @@ class PhoenixEndpointCampaigns extends PhoenixEndpoint {
     return this
       .callAction('reportback', id, data)
       .then((response) => {
-        const body = this.parseStringResponse(response);
+        const body = this.parseNumberResponse(response);
         return Number(body);
       });
   }

--- a/lib/phoenix-endpoint.js
+++ b/lib/phoenix-endpoint.js
@@ -48,7 +48,7 @@ class PhoenixEndpoint {
   }
 
   /**
-   * Helper function to parse response body to a NorthstarUser.
+   * Helper function to parse response body to an object.
    */
   parseResponse(response) {
     if (!response.body) {
@@ -58,7 +58,7 @@ class PhoenixEndpoint {
   }
 
   /**
-   * Helper function to parse response body to a NorthstarUser.
+   * Helper function to parse response body to a String.
    */
   parseStringResponse(response) {
     if (!response.body) {
@@ -70,6 +70,23 @@ class PhoenixEndpoint {
     return String(arrayResponse[0]);
   }
 
+  /**
+   * Helper function to parse response body to a Number.
+   */
+  parseNumberResponse(response) {
+    if (!response.body) {
+      throw new Error('Cannot parse API response.');
+    }
+    // When a string is returned instead of a JSON, it is formatted
+    // as a single-element array containing this number.
+    const arrayResponse = response.body;
+    const number = Number(arrayResponse[0]);
+    // A failed request may contain false as the value returned.
+    if (isNaN(number)) {
+      throw new Error('Request failed.');
+    }
+    return number;
+  }
 }
 
 module.exports = PhoenixEndpoint;

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
   "homepage": "https://github.com/DoSomething/phoenix-js#readme",
   "devDependencies": {
     "@dosomething/eslint-config": "^1.1.1",
+    "dotenv": "^2.0.0",
     "eslint": "^2.10.2",
     "eslint-plugin-react": "^5.1.1",
     "mocha": "^2.5.2",
-    "dotenv": "^2.0.0",
+    "nock": "^8.0.0",
     "should": "^8.4.0"
   },
   "dependencies": {

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -1,12 +1,85 @@
 'use strict';
 
 /**
+ * Imports.
+ */
+const helper = require('./helpers/test-helper');
+const nock = require('nock');
+
+/**
  * Setup.
  */
 require('dotenv').config({ silent: true });
 
+const campaignId = helper.getTestCampaignId();
+const userId = helper.getTestUserId();
+const sessionId = '2f5DO-U9tIACES3vZimgtUaN2ontgBxoyn4-Ds-Zcmg';
+const sessionName = 'SSESS2e2a742ee2c3bda949b2c6b2b81d9941';
+const token = '-XmDawHfJ3MRBFGgBvPaF4_RlHq0Dp_xfffGimzr6mM';
+
+const phoenixApi = nock(process.env.PHOENIX_REST_API_BASEURI);
+const phoenixSession = {
+  sessid: sessionId,
+  session_name: sessionName,
+  token,
+  user: {
+    uid: userId,
+  },
+};
+
+phoenixApi
+  .post('/auth/login')
+  .reply(200, phoenixSession);
+
+phoenixApi
+  .post('/system/connect')
+  .reply(200, {
+    user: { uid: 0 },
+    sessid: sessionId,
+    session_name: sessionName,
+  });
+
+phoenixApi
+  .post('/auth/login')
+  .reply(200, phoenixSession)
+  .post('/system/connect')
+  .reply(200, {
+    user: { uid: userId },
+    sessid: sessionId,
+    session_name: sessionName,
+  });
+
+phoenixApi
+  .post('/auth/login')
+  .reply(200, phoenixSession)
+  .post('/users/get_member_count')
+  .reply(200, {
+    formatted: '9,596,441,002',
+    readable: '9.5 billion',
+  });
+
+phoenixApi
+  .post('/auth/login')
+  .reply(200, phoenixSession)
+  .post(`/users/${userId}/password_reset_url`)
+  .reply(200, ['https://slothbot.ds.org/user/reset/5/14744/-02tH-1R8/login']);
+
+phoenixApi
+  .post('/auth/login')
+  .reply(200, phoenixSession)
+  .post(`/campaigns/${campaignId}/signup`)
+  // Return a random number for Signup id.
+  .reply(200, [347333233]);
+
+phoenixApi
+  .post('/auth/login')
+  .reply(200, phoenixSession)
+  .post(`/campaigns/${campaignId}/reportback`)
+  // Return a random number for Reportback id.
+  .reply(200, [234200]);
+
 /**
- * Run rests.
+ * Run tests.
  */
 require('./lib/environment.test');
 require('./lib/constructor.test');

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -12,3 +12,4 @@ require('./lib/environment.test');
 require('./lib/constructor.test');
 require('./lib/system.test');
 require('./lib/user.test');
+require('./lib/campaigns.test');

--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -30,6 +30,14 @@ module.exports = {
     });
   },
 
+  getTestCampaignId() {
+    return 1672;
+  },
+
+  getTestPostSource() {
+    return 'phoenix-js-test';
+  },
+
   getTestUserId() {
     return 1700275;
   },

--- a/test/lib/campaigns.test.js
+++ b/test/lib/campaigns.test.js
@@ -6,11 +6,12 @@
 const helper = require('../helpers/test-helper');
 const PhoenixEndpointCampaigns = require('../../lib/phoenix-endpoint-campaigns');
 
-const testCampaignId = 1672;
-const testSource = 'phoenix-js-test';
+const client = helper.getAuthorizedClient();
+const testCampaignId = helper.getTestCampaignId();
+const testSource = helper.getTestPostSource();
 
 /**
- * Test PhoenixClient campaign calls.
+ * Test PhoenixClient campaign calls with an authorized client.
  */
 
 describe('PhoenixClient.Campaigns', () => {
@@ -21,7 +22,6 @@ describe('PhoenixClient.Campaigns', () => {
   });
 
   it('signup() returns a number', () => {
-    const client = helper.getAuthorizedClient();
     const data = {
       uid: helper.getTestUserId(),
       source: testSource,
@@ -33,7 +33,6 @@ describe('PhoenixClient.Campaigns', () => {
   });
 
   it('reportback() returns a number', () => {
-    const client = helper.getAuthorizedClient();
     const data = {
       uid: helper.getTestUserId(),
       quantity: 42,

--- a/test/lib/campaigns.test.js
+++ b/test/lib/campaigns.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const helper = require('../helpers/test-helper');
+const PhoenixEndpointCampaigns = require('../../lib/phoenix-endpoint-campaigns');
+
+const testCampaignId = 1672;
+const testSource = 'phoenix-js-test';
+
+/**
+ * Test PhoenixClient campaign calls.
+ */
+
+describe('PhoenixClient.Campaigns', () => {
+  it('should be exposed', () => {
+    helper.getAuthorizedClient()
+      .should.have.property('Campaigns')
+      .which.is.instanceof(PhoenixEndpointCampaigns);
+  });
+
+  it('signup() returns a number', () => {
+    const client = helper.getAuthorizedClient();
+    const data = {
+      uid: helper.getTestUserId(),
+      source: testSource,
+    };
+    const response = client.Campaigns.signup(testCampaignId, data);
+    return response.should.eventually.match((signupId) => {
+      signupId.should.be.a.Number().and.not.equal(0);
+    });
+  });
+
+  it('reportback() returns a number', () => {
+    const client = helper.getAuthorizedClient();
+    const data = {
+      uid: helper.getTestUserId(),
+      quantity: 42,
+      caption: 'Test caption',
+      why_participated: 'Test why_participated',
+      file_url: 'https://yt3.ggpht.com/-tG6go-Bifk0/AAAAAAAAAAI/AAAAAAAAAAA/2oa2dv3cVqM/s900-c-k-no-mo-rj-c0xffffff/photo.jpg',
+      source: testSource,
+    };
+    const response = client.Campaigns.reportback(testCampaignId, data);
+    return response.should.eventually.match((reportbackId) => {
+      reportbackId.should.be.a.Number().and.not.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
#### What's this PR do?

Closes #11, using `callAction` on a new `phoenix-endpoint-campaigns` to implement `Campaigns.signup(id, data)` and `Campaigns.reportback(id, data)`.
#### Any background context you want to provide?

Adds Nock to avoid running into issues with creating tests that post Signups with the same User and Campaign (not permitted) -- and to avoid adding `Users.create` function just for the sake of automated testing
#### Relevant tickets
- Fixes #11
- https://github.com/DoSomething/northstar-js/issues/11#issuecomment-246496549
