### PR TITLE
Adds Campaigns.get and Campaigns.index functions

### DIFF
--- a/lib/phoenix-campaign.js
+++ b/lib/phoenix-campaign.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/**
+ * PhoenixCampaign.
+ */
+class PhoenixCampaign {
+
+  // Construct from JSON.
+  constructor(data) {
+    this.id = data.id;
+    this.title = data.title;
+    this.tagline = data.tagline;
+    this.status = data.status;
+  }
+
+}
+
+module.exports = PhoenixCampaign;

--- a/lib/phoenix-campaign.js
+++ b/lib/phoenix-campaign.js
@@ -11,6 +11,13 @@ class PhoenixCampaign {
     this.title = data.title;
     this.tagline = data.tagline;
     this.status = data.status;
+    this.uri = data.uri;
+    this.reportbackInfo = {
+      confirmationMessage: data.reportback_info.confirmation_message,
+      copy: data.reportback_info.copy,
+      noun: data.reportback_info.noun,
+      verb: data.reportback_info.verb,
+    };
   }
 
 }

--- a/lib/phoenix-endpoint-campaigns.js
+++ b/lib/phoenix-endpoint-campaigns.js
@@ -28,6 +28,15 @@ class PhoenixEndpointCampaigns extends PhoenixEndpoint {
   }
 
   /**
+   * Get campaigns index.
+   */
+  index(query) {
+    return this
+      .executeGet(`${this.endpoint}`, query)
+      .then(response => this.parseIndex(response));
+  }
+
+  /**
    * Helper function to parse response body to a PhoenixCampaign.
    */
   parseGet(response) {
@@ -36,6 +45,17 @@ class PhoenixEndpointCampaigns extends PhoenixEndpoint {
     }
 
     return new PhoenixCampaign(response.body.data);
+  }
+
+  /**
+   * Helper function to parse response body to an array of NorthstarSignups.
+   */
+  parseIndex(response) {
+    if (!response.body.data) {
+      throw new Error('Cannot parse API index response.');
+    }
+
+    return response.body.data.map(row => new PhoenixCampaign(row));
   }
 
   /**

--- a/lib/phoenix-endpoint-campaigns.js
+++ b/lib/phoenix-endpoint-campaigns.js
@@ -4,7 +4,7 @@
  * Imports.
  */
 const PhoenixEndpoint = require('./phoenix-endpoint');
-
+const PhoenixCampaign = require('./phoenix-campaign');
 
 /**
  * PhoenixEndpointCampaigns.
@@ -18,12 +18,24 @@ class PhoenixEndpointCampaigns extends PhoenixEndpoint {
   }
 
   /**
-   * Post Signup for given Campaign id and data.
+   * Get single campaign by id.
    */
-  signup(id, data) {
+  get(id) {
+    // TODO: check type to be in allowed data.
     return this
-      .callAction('signup', id, data)
-      .then(response => this.parseNumberResponse(response));
+      .executeGet(`${this.endpoint}/${id}`)
+      .then(response => this.parseGet(response));
+  }
+
+  /**
+   * Helper function to parse response body to a PhoenixCampaign.
+   */
+  parseGet(response) {
+    if (!response.body.data) {
+      throw new Error('Cannot parse API get response as a PhoenixCampaign.');
+    }
+
+    return new PhoenixCampaign(response.body.data);
   }
 
   /**
@@ -34,6 +46,16 @@ class PhoenixEndpointCampaigns extends PhoenixEndpoint {
       .callAction('reportback', id, data)
       .then(response => this.parseNumberResponse(response));
   }
+
+  /**
+   * Post Signup for given Campaign id and data.
+   */
+  signup(id, data) {
+    return this
+      .callAction('signup', id, data)
+      .then(response => this.parseNumberResponse(response));
+  }
+
 }
 
 module.exports = PhoenixEndpointCampaigns;

--- a/lib/phoenix-endpoint.js
+++ b/lib/phoenix-endpoint.js
@@ -26,6 +26,22 @@ class PhoenixEndpoint {
   }
 
   /**
+   * Helper function to execute simple get.
+   */
+  executeGet(endpoint, query) {
+    const agent = request
+      .get(`${this.client.baseURI}/${endpoint}`)
+      .accept('json');
+
+    // Set query string.
+    if (query) {
+      agent.query(query);
+    }
+
+    return agent;
+  }
+
+  /**
    * Helper function to execute simple post.
    */
   executePost(endpoint, data) {

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -31,6 +31,12 @@ const phoenixCampaign = {
   title: 'Fur Your Information',
   tagline: 'Next question',
   status: 'active',
+  reportback_info: {
+    copy: 'I wanna know what love is',
+    confirmation_message: 'I want you to show me',
+    noun: 'interviews',
+    verb: 'conducted',
+  },
 };
 
 phoenixApi

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -85,8 +85,13 @@ phoenixApi
   .reply(200, [234200]);
 
 phoenixApi
+  .get('/campaigns')
+  .reply(200, { data: [phoenixCampaign] });
+
+phoenixApi
   .get(`/campaigns/${campaignId}`)
   .reply(200, { data: phoenixCampaign });
+
 
 /**
  * Run tests.

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -26,6 +26,12 @@ const phoenixSession = {
     uid: userId,
   },
 };
+const phoenixCampaign = {
+  id: campaignId,
+  title: 'Fur Your Information',
+  tagline: 'Next question',
+  status: 'active',
+};
 
 phoenixApi
   .post('/auth/login')
@@ -77,6 +83,10 @@ phoenixApi
   .post(`/campaigns/${campaignId}/reportback`)
   // Return a random number for Reportback id.
   .reply(200, [234200]);
+
+phoenixApi
+  .get(`/campaigns/${campaignId}`)
+  .reply(200, { data: phoenixCampaign });
 
 /**
  * Run tests.

--- a/test/lib/campaigns.test.js
+++ b/test/lib/campaigns.test.js
@@ -4,6 +4,7 @@
  * Imports.
  */
 const helper = require('../helpers/test-helper');
+const PhoenixCampaign = require('../../lib/phoenix-campaign');
 const PhoenixEndpointCampaigns = require('../../lib/phoenix-endpoint-campaigns');
 
 const client = helper.getAuthorizedClient();
@@ -15,17 +16,38 @@ const testSource = helper.getTestPostSource();
  */
 
 describe('PhoenixClient.Campaigns', () => {
+  /**
+   * Helper: validate campaign object.
+   */
+  function testCampaign(campaign) {
+    campaign.should.be.an.instanceof(PhoenixCampaign);
+    campaign.should.have.properties(['id', 'title', 'tagline', 'status']);
+  }
+  /**
+   * Helper: validate array of campaign objects.
+   */
+  function testCampaigns(campaigns) {
+    campaigns.should.be.an.instanceof(Array);
+    const campaign = campaigns[0];
+    campaign.should.match(testCampaign);
+  }
+
   it('should be exposed', () => {
     helper.getAuthorizedClient()
       .should.have.property('Campaigns')
       .which.is.instanceof(PhoenixEndpointCampaigns);
   });
 
-  it('get() returns a Campaign', () => {
+  it('Signups.get() returns a Campaign', () => {
     const response = client.Campaigns.get(testCampaignId);
-    return response.should.eventually.match((campaign) => {
-      campaign.id.should.be.a.Number().and.not.equal(0);
-    });
+    response.should.be.a.Promise();
+    return response.should.eventually.match(testCampaign);
+  });
+
+  it('Signups.index() returns array of Campaigns', () => {
+    const response = client.Campaigns.index();
+    response.should.be.a.Promise();
+    return response.should.eventually.match(testCampaigns);
   });
 
   it('signup() returns a number', () => {

--- a/test/lib/campaigns.test.js
+++ b/test/lib/campaigns.test.js
@@ -21,6 +21,13 @@ describe('PhoenixClient.Campaigns', () => {
       .which.is.instanceof(PhoenixEndpointCampaigns);
   });
 
+  it('get() returns a Campaign', () => {
+    const response = client.Campaigns.get(testCampaignId);
+    return response.should.eventually.match((campaign) => {
+      campaign.id.should.be.a.Number().and.not.equal(0);
+    });
+  });
+
   it('signup() returns a number', () => {
     const data = {
       uid: helper.getTestUserId(),

--- a/test/lib/campaigns.test.js
+++ b/test/lib/campaigns.test.js
@@ -38,13 +38,13 @@ describe('PhoenixClient.Campaigns', () => {
       .which.is.instanceof(PhoenixEndpointCampaigns);
   });
 
-  it('Signups.get() returns a Campaign', () => {
+  it('Campaigns.get() returns a Campaign', () => {
     const response = client.Campaigns.get(testCampaignId);
     response.should.be.a.Promise();
     return response.should.eventually.match(testCampaign);
   });
 
-  it('Signups.index() returns array of Campaigns', () => {
+  it('Campaigns.index() returns array of Campaigns', () => {
     const response = client.Campaigns.index();
     response.should.be.a.Promise();
     return response.should.eventually.match(testCampaigns);


### PR DESCRIPTION
#### What's this PR do?
- Adds `phoenix-campaign` class
- Adds `Campaigns.get` and `Campaigns.index` to Campaigns endpoint to return single/array of Campaigns
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

Will be used to populate the Gambit `campaigns` cache in its `config` database.
