### PR TITLE
Adds campaign.currentRun property

### DIFF
--- a/lib/phoenix-campaign.js
+++ b/lib/phoenix-campaign.js
@@ -13,8 +13,8 @@ class PhoenixCampaign {
     this.status = data.status;
     this.uri = data.uri;
     this.type = data.type;
-    this.currentRun = {
-      en: data.campaign_runs.current.en.id,
+    this.currentCampaignRun = {
+      id: data.campaign_runs.current.en.id,
     };
     this.reportbackInfo = {
       confirmationMessage: data.reportback_info.confirmation_message,

--- a/lib/phoenix-campaign.js
+++ b/lib/phoenix-campaign.js
@@ -13,6 +13,9 @@ class PhoenixCampaign {
     this.status = data.status;
     this.uri = data.uri;
     this.type = data.type;
+    this.currentRun = {
+      en: data.campaign_runs.current.en.id,
+    };
     this.reportbackInfo = {
       confirmationMessage: data.reportback_info.confirmation_message,
       copy: data.reportback_info.copy,

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -41,6 +41,11 @@ const phoenixCampaign = {
   facts: {
     problem: 'Sweet child o mine',
   },
+  campaign_runs: {
+    current: {
+      en: { id: 6270 },
+    },
+  },
 };
 
 phoenixApi


### PR DESCRIPTION
#### What's this PR do?

Exposes the `campaign_runs.current` object as a `currentCampaignRun` property.
#### Any background context you want to provide?

It'd be cleaner to include the Campaign Run in the Mobile Commons Groups we need to create in https://github.com/DoSomething/gambit/issues/673
