### PR TITLE
Adds check for false in parseNumberResponse

### DIFF
--- a/lib/phoenix-endpoint.js
+++ b/lib/phoenix-endpoint.js
@@ -93,14 +93,20 @@ class PhoenixEndpoint {
     if (!response.body) {
       throw new Error('Cannot parse API response.');
     }
+
     // When a string is returned instead of a JSON, it is formatted
     // as a single-element array containing this number.
     const arrayResponse = response.body;
-    const number = Number(arrayResponse[0]);
+    const result = arrayResponse[0];
     // A failed request may contain false as the value returned.
-    if (isNaN(number)) {
-      throw new Error('Request failed.');
+    if (result === false) {
+      throw new Error('API response is false.');
     }
+    const number = Number(result);
+    if (isNaN(number)) {
+      throw new Error('API response is not a number.');
+    }
+
     return number;
   }
 }


### PR DESCRIPTION
#### What's this PR do?
Checks for a value of `false` in a Phoenix API response and throws an error if we're expecting a numeric value.

#### Relevant tickets
Fixes #17, https://github.com/DoSomething/gambit/issues/827

#### Checklist
- [ ] Run tests
- [ ] Add new or update existing tests if applicable
