### PR TITLE
Signups endpoint

### DIFF
--- a/lib/phoenix-client.js
+++ b/lib/phoenix-client.js
@@ -7,6 +7,7 @@ const PhoenixEndpointUser = require('./phoenix-endpoint-user');
 const PhoenixEndpointAuth = require('./phoenix-endpoint-auth');
 const PhoenixEndpointSystem = require('./phoenix-endpoint-system');
 const PhoenixEndpointCampaigns = require('./phoenix-endpoint-campaigns');
+const PhoenixEndpointSignups = require('./phoenix-endpoint-signups');
 const VERSION = require('../package.json').version;
 
 /**
@@ -39,6 +40,7 @@ class PhoenixClient {
     this.User = new PhoenixEndpointUser(this);
     this.System = new PhoenixEndpointSystem(this);
     this.Campaigns = new PhoenixEndpointCampaigns(this);
+    this.Signups = new PhoenixEndpointSignups(this);
   }
 
   authorizeSession(opts) {

--- a/lib/phoenix-endpoint-signups.js
+++ b/lib/phoenix-endpoint-signups.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const PhoenixEndpoint = require('./phoenix-endpoint');
+const PhoenixSignup = require('./phoenix-signup');
+
+/**
+ * NorthstarEndpointSignups.
+ */
+
+class PhoenixEndpointSignups extends PhoenixEndpoint {
+
+  constructor(client) {
+    super(client);
+    this.endpoint = 'signups';
+  }
+
+  /**
+   * Get single signup by id.
+   */
+  get(id) {
+    // TODO: check type to be in allowed data.
+    return this
+      .executeGet(`${this.endpoint}/${id}`)
+      .then(response => this.parseGet(response));
+  }
+
+  /**
+   * Get signups index.
+   */
+  index(query) {
+    return this
+      .executeGet(`${this.endpoint}`, query)
+      .then(response => this.parseIndex(response));
+  }
+
+  /**
+   * Helper function to parse response body to a NorthstarSignup.
+   */
+  parseGet(response) {
+    if (!response.body.data) {
+      throw new Error('Cannot parse API get response as a PhoenixSignup.');
+    }
+
+    return new PhoenixSignup(response.body.data);
+  }
+
+  /**
+   * Helper function to parse response body to an array of NorthstarSignups.
+   */
+  parseIndex(response) {
+    if (!response.body.data) {
+      throw new Error('Cannot parse API index response.');
+    }
+
+    return response.body.data.map(row => new PhoenixSignup(row));
+  }
+}
+
+module.exports = PhoenixEndpointSignups;

--- a/lib/phoenix-signup.js
+++ b/lib/phoenix-signup.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * PhoenixSignup.
+ */
+
+class PhoenixSignup {
+
+  // Construct from JSON.
+  constructor(data) {
+    this.id = data.id;
+    this.campaign = data.campaign.id;
+    this.user = data.user.id;
+    this.createdAt = data.created_at;
+    if (data.campaign_run) {
+      this.campaignRun = {
+        id: data.campaign_run.id,
+        current: data.campaign_run.current,
+      };
+    }
+    if (data.reportback) {
+      this.reportback = {
+        id: data.reportback.id,
+        quantity: data.reportback.quantity,
+      };
+    }
+  }
+
+}
+
+module.exports = PhoenixSignup;

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -12,7 +12,9 @@ const nock = require('nock');
 require('dotenv').config({ silent: true });
 
 const campaignId = helper.getTestCampaignId();
+const signupId = helper.getTestSignupId();
 const userId = helper.getTestUserId();
+
 const sessionId = '2f5DO-U9tIACES3vZimgtUaN2ontgBxoyn4-Ds-Zcmg';
 const sessionName = 'SSESS2e2a742ee2c3bda949b2c6b2b81d9941';
 const token = '-XmDawHfJ3MRBFGgBvPaF4_RlHq0Dp_xfffGimzr6mM';
@@ -45,6 +47,21 @@ const phoenixCampaign = {
     current: {
       en: { id: 6270 },
     },
+  },
+};
+const phoenixSignup = {
+  id: signupId,
+  campaign: {
+    id: campaignId,
+  },
+  campaign_run: {
+    id: 7626,
+  },
+  reportback: {
+    quantity: 23,
+  },
+  user: {
+    id: userId,
   },
 };
 
@@ -107,6 +124,13 @@ phoenixApi
   .get(`/campaigns/${campaignId}`)
   .reply(200, { data: phoenixCampaign });
 
+phoenixApi
+  .get('/signups')
+  .reply(200, { data: [phoenixSignup] });
+
+phoenixApi
+  .get(`/signups/${signupId}`)
+  .reply(200, { data: phoenixSignup });
 
 /**
  * Run tests.
@@ -116,3 +140,4 @@ require('./lib/constructor.test');
 require('./lib/system.test');
 require('./lib/user.test');
 require('./lib/campaigns.test');
+require('./lib/signups.test');

--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -38,6 +38,10 @@ module.exports = {
     return 'phoenix-js-test';
   },
 
+  getTestSignupId() {
+    return 3081649;
+  },
+
   getTestUserId() {
     return 1700275;
   },

--- a/test/lib/signups.test.js
+++ b/test/lib/signups.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const helper = require('../helpers/test-helper');
+const PhoenixSignup = require('../../lib/phoenix-signup');
+const PhoenixEndpointSignups = require('../../lib/phoenix-endpoint-signups');
+
+const client = helper.getAuthorizedClient();
+const testSignupId = helper.getTestSignupId();
+
+/**
+ * Test PhoenixClient Signups calls with an authorized client.
+ */
+
+describe('PhoenixClient.Signups', () => {
+  /**
+   * Helper: validate signup object.
+   */
+  function testSignup(signup) {
+    signup.should.be.an.instanceof(PhoenixSignup);
+    signup.should.have.properties(['id', 'campaign', 'campaignRun', 'reportback', 'user']);
+  }
+  /**
+   * Helper: validate array of campaign objects.
+   */
+  function testSignups(signups) {
+    signups.should.be.an.instanceof(Array);
+    const signup = signups[0];
+    signup.should.match(testSignup);
+  }
+
+  it('should be exposed', () => {
+    helper.getAuthorizedClient()
+      .should.have.property('Signups')
+      .which.is.instanceof(PhoenixEndpointSignups);
+  });
+
+  it('Signups.get() returns a Signup', () => {
+    const response = client.Signups.get(testSignupId);
+    response.should.be.a.Promise();
+    return response.should.eventually.match(testSignup);
+  });
+
+  it('Signups.index() returns array of Signups', () => {
+    const response = client.Signups.index();
+    response.should.be.a.Promise();
+    return response.should.eventually.match(testSignups);
+  });
+});


### PR DESCRIPTION
#### What's this PR do?
Adds a `client.Signups` endpoint to support GET `/signups` and GET `/signups/:id` requests.

#### Any background context you want to provide?
This is close to a copy/paste job from our Northstar JS library. The Northstar Signups endpoint is a proxy for the Phoenix endpoint, and currently not feeling well per https://github.com/DoSomething/phoenix/issues/7329.

This is a hotfix to close out https://github.com/DoSomething/gambit/issues/827#issuecomment-289100468 -- last step would be to update Gambit to use its Phoenix client to query Signups instead of the Northstar client.


#### Checklist
- [x] Run tests
- [x] Add new or update existing tests if applicable

cc @rapala61 